### PR TITLE
Remove invalid !important in GTK CSS

### DIFF
--- a/themes/src/sass/gtk/apps/_misc.scss
+++ b/themes/src/sass/gtk/apps/_misc.scss
@@ -481,7 +481,7 @@ window.background.csd {
 }
 
 dialog-host > floating-sheet > sheet > widget.response-area {
-	padding: 6px !important;
+	padding: 6px;
 }
 
 //


### PR DESCRIPTION
This actually improves the startup time of various GTK apps by like 1-2 seconds on my machine.